### PR TITLE
Support for OData Not Equals Operator

### DIFF
--- a/Denomica.OData.Cosmos.Extensions/CosmosExtensionMethods.cs
+++ b/Denomica.OData.Cosmos.Extensions/CosmosExtensionMethods.cs
@@ -138,6 +138,7 @@ namespace Denomica.OData.Cosmos.Extensions
                 case BinaryOperatorKind.GreaterThanOrEqual:
                 case BinaryOperatorKind.LessThan:
                 case BinaryOperatorKind.LessThanOrEqual:
+                case BinaryOperatorKind.NotEqual:
                     builder
                         .AppendFilterNode(node.Left)
                         .AppendQueryTextIf(" =", node.OperatorKind == BinaryOperatorKind.Equal)

--- a/Denomica.OData.Tests/CosmosTests.cs
+++ b/Denomica.OData.Tests/CosmosTests.cs
@@ -235,6 +235,17 @@ namespace Denomica.OData.Tests
             Assert.IsFalse(results.Any(x => x.Id == e2.Id));
         }
 
+        [TestMethod]
+        public void CreateQueryDefinition13()
+        {
+            var uriParser = new EdmModelBuilder()
+                .AddEntityType<Employee>("Id", "employees")
+                .Build()
+                .CreateUriParser("/employees?$filter=hometown ne 'Helsinki'");
+
+            var queryDef = uriParser.CreateQueryDefinition();
+        }
+
 
 
         /// <summary>


### PR DESCRIPTION
Creating query definition from OData URI now also supports the Not Equal operator. Closes #1.